### PR TITLE
Fix JEI plugin failure when no potions are registered to the zeta registry, fix crash from ForgeZGatherHints

### DIFF
--- a/src/main/java/org/violetmoon/zeta/registry/ZetaRegistry.java
+++ b/src/main/java/org/violetmoon/zeta/registry/ZetaRegistry.java
@@ -285,6 +285,6 @@ public abstract class ZetaRegistry {
 	 * Gets all the registered objects from this Zeta
 	 */
 	public <O> Collection<Holder<O>> getRegisteredObjects(ResourceKey<Registry<O>> registry) {
-		return (Collection<Holder<O>>) (Collection) myRegisteredObjects.get((ResourceKey) registry);
+		return (Collection<Holder<O>>) (Collection) myRegisteredObjects.getOrDefault((ResourceKey) registry, List.of());
 	}
 }

--- a/src/main/java/org/violetmoon/zetaimplforge/event/load/ForgeZGatherHints.java
+++ b/src/main/java/org/violetmoon/zetaimplforge/event/load/ForgeZGatherHints.java
@@ -4,11 +4,12 @@ import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.IModBusEvent;
 import org.violetmoon.zeta.config.ConfigFlagManager;
 import org.violetmoon.zeta.event.load.ZGatherHints;
 import org.violetmoon.zeta.module.ZetaModule;
 
-public class ForgeZGatherHints extends Event implements ZGatherHints {
+public class ForgeZGatherHints extends Event implements ZGatherHints, IModBusEvent {
     private final ZGatherHints wrapped;
 
     public ForgeZGatherHints(ZGatherHints e) {


### PR DESCRIPTION
This PR fixes two issues:

* This `getRegisteredObjects` method can currently return null and crash the JEI plugin.
* `ForgeZGatherHints` needs to implement `IModBusEvent` in order to be fired on the mod even bus