### PR TITLE
1.21 port fixes

### DIFF
--- a/dependencies.properties
+++ b/dependencies.properties
@@ -1,1 +1,1 @@
-neoforge=21.1.62
+neoforge=21.1.63

--- a/src/main/java/org/violetmoon/zeta/advancement/AdvancementModifierRegistry.java
+++ b/src/main/java/org/violetmoon/zeta/advancement/AdvancementModifierRegistry.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.function.BooleanSupplier;
 
 import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.core.Holder;
 import org.violetmoon.zeta.Zeta;
 import org.violetmoon.zeta.advancement.modifier.ASeedyPlaceModifier;
 import org.violetmoon.zeta.advancement.modifier.AdventuringTimeModifier;
@@ -121,7 +122,7 @@ public class AdvancementModifierRegistry {
 		}
 
 		@Override
-		public IAdvancementModifier createFuriousCocktailMod(BooleanSupplier isPotion, Set<MobEffect> effects) {
+		public IAdvancementModifier createFuriousCocktailMod(BooleanSupplier isPotion, Set<Holder<MobEffect>> effects) {
 			return new FuriousCocktailModifier(null, isPotion, effects);
 		}
 

--- a/src/main/java/org/violetmoon/zeta/advancement/modifier/ASeedyPlaceModifier.java
+++ b/src/main/java/org/violetmoon/zeta/advancement/modifier/ASeedyPlaceModifier.java
@@ -33,14 +33,11 @@ public class ASeedyPlaceModifier extends AdvancementModifier {
 
 	@Override
 	public boolean apply(ResourceLocation res, IMutableAdvancement adv) {
-		for(var block : seeds) {
-			Criterion criterion = EnterBlockTrigger.TriggerInstance.entersBlock(block);
-			
+		for(Block block : seeds) {
+			Criterion<EnterBlockTrigger.TriggerInstance> criterion = EnterBlockTrigger.TriggerInstance.entersBlock(block);
 			String name = BuiltInRegistries.BLOCK.getKey(block).toString();
 			adv.addOrCriterion(name, criterion);
 		}
-		
 		return true;
 	}
-
 }

--- a/src/main/java/org/violetmoon/zeta/advancement/modifier/BalancedDietModifier.java
+++ b/src/main/java/org/violetmoon/zeta/advancement/modifier/BalancedDietModifier.java
@@ -36,10 +36,9 @@ public class BalancedDietModifier extends AdvancementModifier {
     @Override
     public boolean apply(ResourceLocation res, IMutableAdvancement adv) {
         ItemLike[] array = items.toArray(ItemLike[]::new);
-        Criterion criterion = ConsumeItemTrigger.TriggerInstance.usedItem(ItemPredicate.Builder.item().of(array));
+        Criterion<ConsumeItemTrigger.TriggerInstance> criterion = ConsumeItemTrigger.TriggerInstance.usedItem(ItemPredicate.Builder.item().of(array));
         String name = BuiltInRegistries.ITEM.getKey(array[0].asItem()).toString();
         adv.addRequiredCriterion(name, criterion);
         return true;
     }
-
 }

--- a/src/main/java/org/violetmoon/zeta/advancement/modifier/FuriousCocktailModifier.java
+++ b/src/main/java/org/violetmoon/zeta/advancement/modifier/FuriousCocktailModifier.java
@@ -3,6 +3,8 @@ package org.violetmoon.zeta.advancement.modifier;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 
+import net.minecraft.advancements.critereon.MobEffectsPredicate;
+import net.minecraft.core.Holder;
 import org.violetmoon.zeta.advancement.AdvancementModifier;
 import org.violetmoon.zeta.api.IMutableAdvancement;
 import org.violetmoon.zeta.module.ZetaModule;
@@ -20,9 +22,9 @@ public class FuriousCocktailModifier extends AdvancementModifier {
 	private static final ResourceLocation TARGET_AE = ResourceLocation.withDefaultNamespace("nether/all_effects");
 
 	final BooleanSupplier isPotion;
-	final Set<MobEffect> effects;
+	final Set<Holder<MobEffect>> effects;
 	
-	public FuriousCocktailModifier(ZetaModule module, BooleanSupplier isPotion, Set<MobEffect> effects) {
+	public FuriousCocktailModifier(ZetaModule module, BooleanSupplier isPotion, Set<Holder<MobEffect>> effects) {
 		super(module);
 		
 		this.isPotion = isPotion;
@@ -36,20 +38,15 @@ public class FuriousCocktailModifier extends AdvancementModifier {
 
 	@Override
 	public boolean apply(ResourceLocation res, IMutableAdvancement adv) {
-		if(!isPotion.getAsBoolean() && res.equals(TARGET_AP))
-			return false;
+		if (!isPotion.getAsBoolean() && res.equals(TARGET_AP)) return false;
 		
-		Criterion crit = adv.getCriterion("all_effects");
-		if(crit != null && crit.triggerInstance() instanceof EffectsChangedTrigger.TriggerInstance ect)  {
-
-			for(MobEffect e : effects)
-				ect.effects().and(e);
-
-			
+		Criterion<?> crit = adv.getCriterion("all_effects");
+		if (crit != null && crit.triggerInstance() instanceof EffectsChangedTrigger.TriggerInstance ect && ect.effects().isPresent()) {
+			for(Holder<MobEffect> e : effects) {
+				ect.effects().get().effectMap().put(e, new MobEffectsPredicate.MobEffectInstancePredicate());
+			}
 			return true;
 		}
-		
 		return false;
 	}
-
 }

--- a/src/main/java/org/violetmoon/zeta/advancement/modifier/GlowAndBeholdModifier.java
+++ b/src/main/java/org/violetmoon/zeta/advancement/modifier/GlowAndBeholdModifier.java
@@ -40,7 +40,7 @@ public class GlowAndBeholdModifier extends AdvancementModifier {
     public boolean apply(ResourceLocation res, IMutableAdvancement adv) {
 
         Block[] array = blocks.toArray(Block[]::new);
-        Criterion criterion = ItemUsedOnLocationTrigger.TriggerInstance.itemUsedOnBlock(
+        Criterion<ItemUsedOnLocationTrigger.TriggerInstance> criterion = ItemUsedOnLocationTrigger.TriggerInstance.itemUsedOnBlock(
                 LocationPredicate.Builder.location().setBlock(
                         BlockPredicate.Builder.block()
                                 .of(array)),

--- a/src/main/java/org/violetmoon/zeta/advancement/modifier/MonsterHunterModifier.java
+++ b/src/main/java/org/violetmoon/zeta/advancement/modifier/MonsterHunterModifier.java
@@ -25,7 +25,6 @@ public class MonsterHunterModifier extends AdvancementModifier {
 	
 	public MonsterHunterModifier(ZetaModule module, Set<EntityType<?>> entityTypes) {
 		super(module);
-		
 		this.entityTypes = entityTypes;
 	}
 
@@ -36,18 +35,16 @@ public class MonsterHunterModifier extends AdvancementModifier {
 
 	@Override
 	public boolean apply(ResourceLocation res, IMutableAdvancement adv) {
-		boolean all = res.equals(TARGET_ALL);
-		
 		for(EntityType<?> type : entityTypes) {
-			Criterion criterion = KilledTrigger.TriggerInstance.playerKilledEntity(EntityPredicate.Builder.entity().entityType(EntityTypePredicate.of(type)));
-			
+			Criterion<KilledTrigger.TriggerInstance> criterion = KilledTrigger.TriggerInstance.playerKilledEntity(EntityPredicate.Builder.entity().entityType(EntityTypePredicate.of(type)));
 			String name = BuiltInRegistries.ENTITY_TYPE.getKey(type).toString();
-			if(all)
+
+			if (res.equals(TARGET_ALL)) {
 				adv.addRequiredCriterion(name, criterion);
-			else adv.addOrCriterion(name, criterion);
+			} else {
+				adv.addOrCriterion(name, criterion);
+			}
 		}
-		
 		return true;
 	}
-
 }

--- a/src/main/java/org/violetmoon/zeta/advancement/modifier/TwoByTwoModifier.java
+++ b/src/main/java/org/violetmoon/zeta/advancement/modifier/TwoByTwoModifier.java
@@ -38,15 +38,11 @@ public class TwoByTwoModifier extends AdvancementModifier {
 
 	@Override
 	public boolean apply(ResourceLocation res, IMutableAdvancement adv) {
-		for(EntityType<?> type : entityTypes) {
-			Criterion criterion = BredAnimalsTrigger.TriggerInstance
-					.bredAnimals(EntityPredicate.Builder.entity().entityType(EntityTypePredicate.of(type)));
-			
+		for (EntityType<?> type : entityTypes) {
+			Criterion<BredAnimalsTrigger.TriggerInstance> criterion = BredAnimalsTrigger.TriggerInstance.bredAnimals(EntityPredicate.Builder.entity().entityType(EntityTypePredicate.of(type)));
 			String name = BuiltInRegistries.ENTITY_TYPE.getKey(type).toString();
 			adv.addRequiredCriterion(name, criterion);
 		}
-		
 		return true;
 	}
-
 }

--- a/src/main/java/org/violetmoon/zeta/api/IAdvancementModifierDelegate.java
+++ b/src/main/java/org/violetmoon/zeta/api/IAdvancementModifierDelegate.java
@@ -3,6 +3,7 @@ package org.violetmoon.zeta.api;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 
+import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.EntityType;
@@ -14,7 +15,7 @@ import net.minecraft.world.level.block.Block;
 public interface IAdvancementModifierDelegate {
 	IAdvancementModifier createAdventuringTimeMod(Set<ResourceKey<Biome>> locations);
 	IAdvancementModifier createBalancedDietMod(Set<ItemLike> items);
-	IAdvancementModifier createFuriousCocktailMod(BooleanSupplier isPotion, Set<MobEffect> effects);
+	IAdvancementModifier createFuriousCocktailMod(BooleanSupplier isPotion, Set<Holder<MobEffect>> effects);
 	IAdvancementModifier createMonsterHunterMod(Set<EntityType<?>> types);
 	IAdvancementModifier createTwoByTwoMod(Set<EntityType<?>> types);
 	IAdvancementModifier createWaxOnWaxOffMod(Set<Block> unwaxed, Set<Block> waxed);

--- a/src/main/java/org/violetmoon/zeta/block/be/ZetaBlockEntity.java
+++ b/src/main/java/org/violetmoon/zeta/block/be/ZetaBlockEntity.java
@@ -29,20 +29,20 @@ public abstract class ZetaBlockEntity extends BlockEntity {
 	@Override
 	protected void saveAdditional(CompoundTag tag, HolderLookup.Provider provider) {
 		super.saveAdditional(tag, provider);
-		writeSharedNBT(tag);
+		writeSharedNBT(tag, provider);
 	}
 
 	@Override
 	protected void loadAdditional(CompoundTag tag, HolderLookup.Provider provider) {
 		super.loadAdditional(tag, provider);
-		readSharedNBT(tag);
+		readSharedNBT(tag, provider);
 	}
 
-	public void writeSharedNBT(CompoundTag cmp) {
+	public void writeSharedNBT(CompoundTag cmp, HolderLookup.Provider provider) {
 		// NO-OP
 	}
 
-	public void readSharedNBT(CompoundTag cmp) {
+	public void readSharedNBT(CompoundTag cmp, HolderLookup.Provider provider) {
 		// NO-OP
 	}
 	
@@ -55,13 +55,13 @@ public abstract class ZetaBlockEntity extends BlockEntity {
 	@Override
 	public CompoundTag getUpdateTag(HolderLookup.Provider provider) {
 		CompoundTag tag = new CompoundTag();
-		writeSharedNBT(tag);
+		writeSharedNBT(tag, provider);
 		return tag;
 	}
 
 	@Override
 	public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket packet, HolderLookup.Provider provider) {
 		super.onDataPacket(net, packet, provider);
-        readSharedNBT(packet.getTag());
+        readSharedNBT(packet.getTag(), provider);
 	}
 }

--- a/src/main/java/org/violetmoon/zeta/event/load/ZGatherAdvancementModifiers.java
+++ b/src/main/java/org/violetmoon/zeta/event/load/ZGatherAdvancementModifiers.java
@@ -3,6 +3,7 @@ package org.violetmoon.zeta.event.load;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 
+import net.minecraft.core.Holder;
 import org.violetmoon.zeta.api.IAdvancementModifier;
 import org.violetmoon.zeta.api.IAdvancementModifierDelegate;
 import org.violetmoon.zeta.event.bus.IZetaLoadEvent;
@@ -26,7 +27,7 @@ public interface ZGatherAdvancementModifiers extends IZetaLoadEvent {
 	default IAdvancementModifier createBalancedDietMod(Set<ItemLike> items) {
 		return getDelegate().createBalancedDietMod(items);
 	}
-	default IAdvancementModifier createFuriousCocktailMod(BooleanSupplier isPotion, Set<MobEffect> effects) {
+	default IAdvancementModifier createFuriousCocktailMod(BooleanSupplier isPotion, Set<Holder<MobEffect>> effects) {
 		return getDelegate().createFuriousCocktailMod(isPotion, effects);
 	}
 	default IAdvancementModifier createMonsterHunterMod(Set<EntityType<?>> types) {

--- a/src/main/java/org/violetmoon/zeta/event/play/entity/ZEntityMobGriefing.java
+++ b/src/main/java/org/violetmoon/zeta/event/play/entity/ZEntityMobGriefing.java
@@ -5,6 +5,8 @@ import org.violetmoon.zeta.event.bus.Resultable;
 
 import net.minecraft.world.entity.Entity;
 
-public interface ZEntityMobGriefing extends IZetaPlayEvent, Resultable {
+public interface ZEntityMobGriefing extends IZetaPlayEvent {
     Entity getEntity();
+    void setCanGrief(boolean canGrief);
+    boolean canGrief();
 }

--- a/src/main/java/org/violetmoon/zeta/event/play/entity/player/ZPlayerInteract.java
+++ b/src/main/java/org/violetmoon/zeta/event/play/entity/player/ZPlayerInteract.java
@@ -19,15 +19,20 @@ public interface ZPlayerInteract extends IZetaPlayEvent, Cancellable {
 
     interface EntityInteractSpecific extends ZPlayerInteract {
         Entity getTarget();
+        void setCancellationResult(InteractionResult result);
     }
 
     interface EntityInteract extends ZPlayerInteract {
         Entity getTarget();
+        void setCancellationResult(InteractionResult result);
     }
 
-    interface RightClickBlock extends ZPlayerInteract { }
+    interface RightClickBlock extends ZPlayerInteract {
+        void setCancellationResult(InteractionResult result);
+    }
 
     interface RightClickItem extends ZPlayerInteract {
         ItemStack getItemStack();
+        void setCancellationResult(InteractionResult result);
     }
 }

--- a/src/main/java/org/violetmoon/zeta/mod/ZetaMod.java
+++ b/src/main/java/org/violetmoon/zeta/mod/ZetaMod.java
@@ -1,5 +1,6 @@
 package org.violetmoon.zeta.mod;
 
+import net.neoforged.bus.api.IEventBus;
 import org.violetmoon.zeta.Zeta;
 import org.violetmoon.zeta.config.ZetaGeneralConfig;
 import org.violetmoon.zeta.event.bus.LoadEvent;
@@ -11,11 +12,11 @@ public class ZetaMod {
 	public static Zeta ZETA;
 	public static ZetaModProxy proxy;
 	
-	public static void start(Zeta zeta, ZetaModProxy proxy) {
+	public static void start(Zeta zeta, ZetaModProxy proxy, IEventBus bus) {
 		ZetaMod.ZETA = zeta;
 		ZetaMod.proxy = proxy;
 
-		ZETA.start();
+		ZETA.start(bus);
 		ZETA.loadModules(null, null, ZetaGeneralConfig.INSTANCE);
 		
 		ZetaModInternalNetwork.init();

--- a/src/main/java/org/violetmoon/zeta/util/SimpleInventoryBlockEntity.java
+++ b/src/main/java/org/violetmoon/zeta/util/SimpleInventoryBlockEntity.java
@@ -12,56 +12,37 @@ package org.violetmoon.zeta.util;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
+import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.WorldlyContainer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.neoforge.items.wrapper.SidedInvWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.violetmoon.zeta.block.be.ZetaBlockEntity;
 
 // formerly from AutoRegLib
 public abstract class SimpleInventoryBlockEntity extends ZetaBlockEntity implements WorldlyContainer {
+
+	protected NonNullList<ItemStack> inventorySlots = NonNullList.withSize(getContainerSize(), ItemStack.EMPTY);
+
 	public SimpleInventoryBlockEntity(BlockEntityType<?> tileEntityTypeIn, BlockPos pos, BlockState state) {
 		super(tileEntityTypeIn, pos, state);
 	}
 
-	protected NonNullList<ItemStack> inventorySlots = NonNullList.withSize(getContainerSize(), ItemStack.EMPTY);
-
 	@Override
-	public void readSharedNBT(CompoundTag par1NBTTagCompound) {
-		if(!needsToSyncInventory())
-			return;
-
-		ListTag var2 = par1NBTTagCompound.getList("Items", 10);
-		clearContent();
-		for(int var3 = 0; var3 < var2.size(); ++var3) {
-			CompoundTag var4 = var2.getCompound(var3);
-			byte var5 = var4.getByte("Slot");
-			if(var5 >= 0 && var5 < inventorySlots.size())
-				inventorySlots.set(var5, ItemStack.of(var4));
-		}
+	public void readSharedNBT(CompoundTag tag, HolderLookup.Provider provider) {
+		if (!needsToSyncInventory()) return;
+		ContainerHelper.loadAllItems(tag, this.inventorySlots, provider);
 	}
 
 	@Override
-	public void writeSharedNBT(CompoundTag par1NBTTagCompound) {
-		if(!needsToSyncInventory())
-			return;
-
-		ListTag var2 = new ListTag();
-		for(int var3 = 0; var3 < inventorySlots.size(); ++var3) {
-			if(!inventorySlots.get(var3).isEmpty()) {
-				CompoundTag var4 = new CompoundTag();
-				var4.putByte("Slot", (byte) var3);
-				inventorySlots.get(var3).save(var4);
-				var2.add(var4);
-			}
-		}
-		par1NBTTagCompound.put("Items", var2);
+	public void writeSharedNBT(CompoundTag tag, HolderLookup.Provider provider) {
+		if (!needsToSyncInventory()) return;
+		ContainerHelper.saveAllItems(tag, this.inventorySlots, provider);
 	}
 
 	protected boolean needsToSyncInventory() {

--- a/src/main/java/org/violetmoon/zetaimplforge/event/play/entity/ForgeZEntityMobGriefing.java
+++ b/src/main/java/org/violetmoon/zetaimplforge/event/play/entity/ForgeZEntityMobGriefing.java
@@ -19,12 +19,12 @@ public class ForgeZEntityMobGriefing implements ZEntityMobGriefing {
     }
 
     @Override
-    public boolean getResult() {
-        return true; //todo: FIX
+    public void setCanGrief(boolean canGrief) {
+        e.setCanGrief(canGrief);
     }
 
     @Override
-    public void setResult(ZResult value) {
-        e.setResult(ForgeZeta.to(value));
+    public boolean canGrief() {
+        return e.canGrief();
     }
 }

--- a/src/main/java/org/violetmoon/zetaimplforge/event/play/entity/player/ForgeZPlayerInteract.java
+++ b/src/main/java/org/violetmoon/zetaimplforge/event/play/entity/player/ForgeZPlayerInteract.java
@@ -79,6 +79,11 @@ public class ForgeZPlayerInteract implements ZPlayerInteract {
         public Entity getTarget() {
             return e.getTarget();
         }
+
+        @Override
+        public void setCancellationResult(InteractionResult result) {
+            e.setCancellationResult(result);
+        }
     }
 
     public static class RightClickBlock extends ForgeZPlayerInteract implements ZPlayerInteract.RightClickBlock {
@@ -87,6 +92,11 @@ public class ForgeZPlayerInteract implements ZPlayerInteract {
         public RightClickBlock(PlayerInteractEvent.RightClickBlock e) {
             super(e);
             this.e = e;
+        }
+
+        @Override
+        public void setCancellationResult(InteractionResult result) {
+            e.setCancellationResult(result);
         }
     }
 
@@ -101,6 +111,11 @@ public class ForgeZPlayerInteract implements ZPlayerInteract {
         @Override
         public ItemStack getItemStack() {
             return e.getItemStack();
+        }
+
+        @Override
+        public void setCancellationResult(InteractionResult result) {
+            e.setCancellationResult(result);
         }
     }
 }

--- a/src/main/java/org/violetmoon/zetaimplforge/mod/ZetaForgeMod.java
+++ b/src/main/java/org/violetmoon/zetaimplforge/mod/ZetaForgeMod.java
@@ -23,9 +23,9 @@ public class ZetaForgeMod {
 		ForgeZeta zeta = new ForgeZeta(Zeta.ZETA_ID, LogManager.getLogger(Zeta.ZETA_ID + "-internal"));
 		
 		ZetaModProxy proxy = Env.unsafeRunForDist(() -> ZetaClientProxy::new, () -> ZetaModProxy::new);
-		Object zetaClient = Env.unsafeRunForDist(() -> () -> new ForgeZetaClient(zeta), () -> () -> new Object());
+		Object zetaClient = Env.unsafeRunForDist(() -> () -> new ForgeZetaClient(zeta), () -> Object::new);
 		
-		ZetaMod.start(zeta, proxy);
+		ZetaMod.start(zeta, proxy, bus);
 		ZetaMod.proxy.setClientZeta(zetaClient);
 		
 		NeoForge.EVENT_BUS.register(ToolInteractionHandler.class);

--- a/src/main/resources/zeta.mixins.json
+++ b/src/main/resources/zeta.mixins.json
@@ -5,7 +5,6 @@
   "refmap": "zeta.mixins.refmap.json",
   "package": "org.violetmoon.zeta.mixin.mixins",
   "mixins": [
-    "AccessorAdvancement",
     "AccessorBlock",
     "AccessorContextAwarePredicate",
     "AccessorItem",


### PR DESCRIPTION
- 88 compile errors left
- MobGriefingEvent no longer uses result
- MobEffects need to be registered with Holder<MobEffect>
- Replace redundant code with functions provided by Mojang
- Move setCancellation events in ForgeZPlayerInteract