### PR TITLE
Discard the recipe digestion map after firing the event

### DIFF
--- a/src/main/java/org/violetmoon/zeta/util/handler/RecipeCrawlHandler.java
+++ b/src/main/java/org/violetmoon/zeta/util/handler/RecipeCrawlHandler.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.google.common.collect.ArrayListMultimap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.violetmoon.zeta.event.bus.IZetaPlayEvent;
@@ -142,7 +143,9 @@ public class RecipeCrawlHandler {
 					digest(recipe, tick.getServer().registryAccess());
 
 				vanillaRecipesToLazyDigest.clear();
-				fire(new ZRecipeCrawl.Digest(vanillaRecipeDigestion, backwardsVanillaDigestion));
+				fire(new ZRecipeCrawl.Digest(ArrayListMultimap.create(vanillaRecipeDigestion), ArrayListMultimap.create(backwardsVanillaDigestion)));
+				vanillaRecipeDigestion.clear();
+				backwardsVanillaDigestion.clear();
 			}
 		}
 	}


### PR DESCRIPTION
This is a faster & simpler alternative to #68 that simply discards the contents of the map after firing `ZRecipeCrawl.Digest` instead of trying to compact them for long-term storage.

A defensive copy is made before providing the multimaps to the event; this is for backwards compatibility in case there are mods that just store a reference to the map and assume they can work off of it till receiving the event again. If preserving that behavior is not a requirement, the defensive copy can be removed.

The memory savings should be at least as good as #68 if not better, as now the map doesn't need to be kept in memory long-term at all. In ATM9 this saves about 400MB of memory. :eyes: 