### PR TITLE
Make `ForgeZetaClient#hackilyGetCurrentClientLevelRegistryAccess` less likely to return null

### DIFF
--- a/src/main/java/org/violetmoon/zetaimplforge/client/ForgeZetaClient.java
+++ b/src/main/java/org/violetmoon/zetaimplforge/client/ForgeZetaClient.java
@@ -5,14 +5,12 @@ import net.minecraft.client.color.block.BlockColor;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.color.item.ItemColor;
 import net.minecraft.client.color.item.ItemColors;
-import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
-import net.neoforged.fml.util.thread.EffectiveSide;
+import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.Nullable;
 import org.violetmoon.zeta.Zeta;
@@ -21,8 +19,6 @@ import org.violetmoon.zeta.client.HumanoidArmorModelGetter;
 import org.violetmoon.zeta.client.ZetaClient;
 import org.violetmoon.zetaimplforge.mixin.mixins.client.AccessorBlockColors;
 import org.violetmoon.zetaimplforge.mixin.mixins.client.AccessorItemColors;
-
-import net.neoforged.neoforge.client.event.*;
 
 public class ForgeZetaClient extends ZetaClient {
     public ForgeZetaClient(Zeta z) {
@@ -56,11 +52,14 @@ public class ForgeZetaClient extends ZetaClient {
 
     @Override
     public RegistryAccess hackilyGetCurrentClientLevelRegistryAccess() {
-        if (EffectiveSide.get().isServer())
-            return ServerLifecycleHooks.getCurrentServer().registryAccess();
-
-        ClientPacketListener conn = Minecraft.getInstance().getConnection();
-        return conn == null ? null : conn.registryAccess();
+		if (ServerLifecycleHooks.getCurrentServer() == null) {
+			if (FMLLoader.getDist().isClient() && Minecraft.getInstance().level != null) {
+				return Minecraft.getInstance().level.registryAccess();
+			}
+		} else {
+			return ServerLifecycleHooks.getCurrentServer().registryAccess();
+		}
+		return null;
     }
 
 }


### PR DESCRIPTION
This allows Quark's Ancient Tomes to append to creative tabs without throwing an error in my very large modpack (after reverting the change from `ForgeZetaClient#hackilyGetCurrentClientLevelRegistryAccess` to `Minecraft#getConnection` in https://github.com/VazkiiMods/Quark/commit/8f284852bdd4b7ce4510afaa555697766428ab7d).

I believe it's using `Minecraft.level` instead of `Minecraft#getConnection` that fixes the issue, but the rest of the code (using `ServerLifecycleHooks`) is what I've been using and has been working in one of my own mods.

For reference, `Minecraft#getConnection` delegates to `Minecraft.player#getConnection` - I guess `level` is set before `player`?