### PR TITLE
Fix for Quark's #4854 issue caused by CPU race condition

### DIFF
--- a/src/main/java/org/violetmoon/zetaimplforge/ForgeZeta.java
+++ b/src/main/java/org/violetmoon/zetaimplforge/ForgeZeta.java
@@ -15,7 +15,6 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLEnvironment;
-import net.minecraftforge.registries.RegisterEvent;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.violetmoon.zeta.Zeta;
@@ -42,7 +41,6 @@ import org.violetmoon.zetaimplforge.config.ConfigEventDispatcher;
 import org.violetmoon.zetaimplforge.config.ForgeBackedConfig;
 import org.violetmoon.zetaimplforge.config.TerribleForgeConfigHackery;
 import org.violetmoon.zetaimplforge.event.ForgeZetaEventBus;
-import org.violetmoon.zetaimplforge.event.load.ForgeZRegister;
 import org.violetmoon.zetaimplforge.item.IForgeItemItemExtensions;
 import org.violetmoon.zetaimplforge.network.ForgeZetaNetworkHandler;
 import org.violetmoon.zetaimplforge.registry.ForgeBrewingRegistry;
@@ -157,22 +155,7 @@ public class ForgeZeta extends Zeta {
 
         //other stuff
         modbus.addListener(EventPriority.LOWEST, CreativeTabManager::buildContents);
-        modbus.addListener(EventPriority.HIGHEST, this::registerHighest);
     }
-
-    private boolean registerDone = false;
-
-    public void registerHighest(RegisterEvent e) {
-        if (registerDone)
-            return;
-
-        registerDone = true; // do this *before* actually registering to prevent weird ??race conditions?? or something?
-        //idk whats going on, all i know is i started the game, got a log with 136 "duplicate criterion id" errors, and i don't want to see that again
-
-        loadBus.fire(new ForgeZRegister(this));
-        loadBus.fire(new ForgeZRegister.Post());
-    }
-
 
     //public void addReloadListener(AddReloadListenerEvent e) {
     //    loadBus.fire(new ForgeZAddReloadListener(e), ZAddReloadListener.class);

--- a/src/main/java/org/violetmoon/zetaimplforge/registry/ForgeZetaRegistry.java
+++ b/src/main/java/org/violetmoon/zetaimplforge/registry/ForgeZetaRegistry.java
@@ -11,15 +11,33 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.RegisterEvent;
+import org.violetmoon.zetaimplforge.event.load.ForgeZRegister;
 
 public class ForgeZetaRegistry extends ZetaRegistry {
 	public ForgeZetaRegistry(ForgeZeta z) {
 		super(z);
 
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onRegisterEvent);
+		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onRegister);
 	}
 
-	private void onRegisterEvent(RegisterEvent event) {
+	private boolean registered;
+
+	public void onRegister(RegisterEvent e) {
+		if (registered) {
+			register(e);
+		} else {
+			registered = true; // RegisterEvent fires for each registry, to prevent multiple unwanted misfires do a 'registry done' check
+			// that, or maybe its cause of both zeta and quark adding this as register event listener, idk
+
+			z.loadBus.fire(new ForgeZRegister(z));
+			z.loadBus.fire(new ForgeZRegister.Post());
+
+			// firing those two events takes up a registry from the RegisterEvent
+			register(e); // make up for that by calling our registry for said registry
+		}
+	}
+
+	private void register(RegisterEvent event) {
 		var key = event.getRegistryKey();
 		ResourceLocation registryRes = key.location();
 		ResourceKey<Registry<Object>> keyGeneric = ResourceKey.createRegistryKey(registryRes);


### PR DESCRIPTION
After some testing I found out that the `RegisterEvent` ignores event listener priority, so the two separate listeners in `ForgeZeta` and `ForgeZetaRegistry` were effectively racing to see who'll be invoked first.

Merging them both into one listener in `ForgeZetaRegistry` solves the issue.